### PR TITLE
パッケージをいくつか追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,14 +222,19 @@ $ ghc-pkg list | grep <pkg_name>
 
 パッケージ名 | 既存 | 最新 | 提案
 -----------|-----|------|-----
+QuickCheck | [2.8.1](https://hackage.haskell.org/package/QuickCheck-2.8.1) | [2.13.2](https://hackage.haskell.org/package/QuickCheck-2.13.2)
 array | [0.5.1.0](https://hackage.haskell.org/package/array-0.5.1.0) | [0.5.3.0](https://hackage.haskell.org/package/array-0.5.3.0)
 attoparsec | [0.13.0.1](https://hackage.haskell.org/package/attoparsec-0.13.0.1) | [0.13.2.2](https://hackage.haskell.org/package/attoparsec-0.13.2.2)
 bytestring | [0.10.6.0](https://hackage.haskell.org/package/bytestring-0.10.6.0) | [0.10.10.0](https://hackage.haskell.org/package/bytestring-0.10.10.0)
 containers | [0.5.6.2](https://hackage.haskell.org/package/containers-0.5.6.2) | [0.6.2.1](https://hackage.haskell.org/package/containers-0.6.2.1)
+deepseq | [1.4.1.1](https://hackage.haskell.org/package/deepseq-1.4.1.1) | [1.4.4.0](https://hackage.haskell.org/package/deepseq-1.4.4.0)
 fgl | [5.5.2.3](https://hackage.haskell.org/package/fgl-5.5.2.3) | [5.7.0.1](https://hackage.haskell.org/package/fgl-5.7.0.1)
+parallel | [3.2.0.6](https://hackage.haskell.org/package/parallel-3.2.0.6) | [3.2.2.0](https://hackage.haskell.org/package/parallel-3.2.2.0)
 parsec | [3.1.9](https://hackage.haskell.org/package/parsec-3.1.9) | [3.1.13.0](https://hackage.haskell.org/package/parsec-3.1.13.0)
 primitive | [0.6.1.0](https://hackage.haskell.org/package/primitive-0.6.1.0) | [0.7.0.0](https://hackage.haskell.org/package/primitive-0.7.0.0)
+random | [1.1](https://hackage.haskell.org/package/random-1.1) | [1.1](https://hackage.haskell.org/package/random-1.1)
 text | [1.2.1.3](https://hackage.haskell.org/package/text-1.2.1.3) | [1.2.3.1](https://hackage.haskell.org/package/text-1.2.3.1)
+transformers | [0.4.2.0](https://hackage.haskell.org/package/transformers-0.4.2.0) | [0.5.6.2](https://hackage.haskell.org/package/transformers-0.5.6.2)
 unordered-containers | [0.2.5.1](https://hackage.haskell.org/package/unordered-containers-0.2.5.1) | [0.2.10.0](https://hackage.haskell.org/package/unordered-containers-0.2.10.0)
 vector | [0.11.0.0](https://hackage.haskell.org/package/vector-0.11.0.0) | [0.12.0.3](https://hackage.haskell.org/package/vector-0.12.0.3)
 
@@ -239,11 +244,13 @@ vector | [0.11.0.0](https://hackage.haskell.org/package/vector-0.11.0.0) | [0.12
 -----------|------|--------
 extra | [1.6.17](https://hackage.haskell.org/package/extra-1.6.17) | Prelude に定義されていない、あったら便利な関数が多数定義されているため。
 heaps | [0.3.6.1](https://hackage.haskell.org/package/heaps-0.3.6.1)
+integer-logarithms | [1.0.3](https://hackage.haskell.org/package/integer-logarithms-1.0.3) | 整数のlogを取るため。
 lens | [4.17.1](https://hackage.haskell.org/package/lens-4.17.1)
 massiv | [0.4.0.0](https://hackage.haskell.org/package/massiv-0.4.0.0) | 高次元のaligned vectorを扱うmoduleであって，「mutable <-> immutable 相互変換可能」「map,fold等がそのまま使える」を満たしているものとして希望した．
+mono-traversable | [1.0.12.0](https://hackage.haskell.org/package/mono-traversable-1.0.12.0) | ByteStringやText等をFoldable/Traversableっぽく扱うためのインターフェースを提供している。
 mwc-random | [0.14.0.0](https://hackage.haskell.org/package/mwc-random-0.14.0.0) | 高速に乱数を生成するため。
 psqueues | [0.2.7.2](https://hackage.haskell.org/package/psqueues-0.2.7.2)
-reflection | [2.1.4](https://hackage.haskell.org/package/reflection-2.1.4)
+reflection | [2.1.4](https://hackage.haskell.org/package/reflection-2.1.4) | 実行時の値に基づいた型レベル自然数を作るため。
 repa | [3.4.1.4](https://hackage.haskell.org/package/repa-3.4.1.4)
 unboxing-vector | [0.1.1.0](https://hackage.haskell.org/package/unboxing-vector-0.1.1.0) | [unboxing-vectorの紹介：newtypeフレンドリーなunboxed vector](https://qiita.com/mod_poppo/items/cf6b66ff16464c170ac2) を参照してください。
 utility-ht | [0.0.14](https://hackage.haskell.org/package/utility-ht)

--- a/spec.md
+++ b/spec.md
@@ -61,23 +61,30 @@ $ cabal user-config update -a store-dir:/opt/.cabal/store
 $ cabal user-config update -a package-db:/opt/.cabal/store
 
 $ cabal v2-install --lib --package-env /opt/.cabal/global.env \
+    QuickCheck-2.13.2 \
     array-0.5.3.0 \
     attoparsec-0.13.2.2 \
     bytestring-0.10.8.2 \
     containers-0.6.0.1 \
+    deepseq-1.4.4.0 \
     extra-1.6.17 \
     fgl-5.7.0.1 \
     heaps-0.3.6.1 \
+    integer-logarithms-1.0.3 \
     lens-4.17.1 \
     massiv-0.4.0.0 \
+    mono-traversable-1.0.12.0 \
     mtl-2.2.2 \
     mwc-random-0.14.0.0 \
+    parallel-3.2.2.0 \
     parsec-3.1.13.0 \
     primitive-0.7.0.0 \
     psqueues-0.2.7.2 \
+    random-1.1 \
     reflection-2.1.4 \
     repa-3.4.1.4 \
     text-1.2.3.1 \
+    transformers-0.5.6.2 \
     unboxing-vector-0.1.1.0 \
     unordered-containers-0.2.10.0 \
     utility-ht-0.0.14 \

--- a/spec.md
+++ b/spec.md
@@ -65,23 +65,23 @@ $ cabal v2-install --lib --package-env /opt/.cabal/global.env \
     attoparsec-0.13.2.2 \
     bytestring-0.10.8.2 \
     containers-0.6.0.1 \
-    fgl-5.7.0.1 \
-    mtl-2.2.2 \
-    parsec-3.1.13.0 \
-    primitive-0.7.0.0 \
-    text-1.2.3.1 \
-    unordered-containers-0.2.10.0 \
-    vector-0.12.0.3 \
     extra-1.6.17 \
+    fgl-5.7.0.1 \
     heaps-0.3.6.1 \
     lens-4.17.1 \
     massiv-0.4.0.0 \
+    mtl-2.2.2 \
     mwc-random-0.14.0.0 \
+    parsec-3.1.13.0 \
+    primitive-0.7.0.0 \
     psqueues-0.2.7.2 \
     reflection-2.1.4 \
     repa-3.4.1.4 \
+    text-1.2.3.1 \
     unboxing-vector-0.1.1.0 \
+    unordered-containers-0.2.10.0 \
     utility-ht-0.0.14 \
+    vector-0.12.0.3 \
     vector-algorithms-0.8.0.1
 ```
 


### PR DESCRIPTION
現在のAtCoder環境で使えるパッケージ：

- QuickCheck: コード中にテストを書けると便利？
- deepseq: みんな大好きnormal form
- parallel: AtCoder上では並列実行できなくても、ソースの互換性的な観点から
- random: Haskell入門書とかではこちらの方がポピュラーな気がするので。初心者用
- transformers: mtlにないトランスフォーマーがいくつかあるっぽい

新規：

- integer-logarithms: 整数のlog2を計算するのに便利（固定長整数なら `finiteBitSize x - countLeadingZeros x - 1` でできるけど……）
- mono-traversable: ByteStringやUnboxed Vector等に対してFoldable, Traversable的なインターフェースを提供する

その他：

- parsec-3.1.14.0 が出ているのでバージョンを上げようとしましたが GHC 8.6.5 付属の parsec-3.1.13.0 と衝突するっぽいので parsec-3.1.13.0 のままにしました
